### PR TITLE
Make include dependency explicit

### DIFF
--- a/src/mylib/CMakeLists.txt
+++ b/src/mylib/CMakeLists.txt
@@ -8,6 +8,7 @@ target_include_directories(mylib PUBLIC .)
 # unit tests
 add_executable(mylib_tests
     "mylib/MyClass.test.cpp"
+    "mylib/MyClass.h"
 )
 target_link_libraries(mylib_tests
     PRIVATE gtest_main mylib


### PR DESCRIPTION
Unit test should rebuild if included headers change.